### PR TITLE
feat: :sparkles: Sandbox option for Melhor Envio API

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ const plugins = [
     options: {
       apiToken: process.env.MELHOR_ENVIO_API_TOKEN,
       postalCode: process.env.MELHOR_ENVIO_POSTAL_CODE,
+      sandbox: process.env.ENVIRONMENT, // Set true or "development" to use the sandbox environment
     },
   },
 ];

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -8,15 +8,19 @@ import {
 class Client {
   private readonly axios: axios.AxiosInstance;
 
-  constructor(token: string) {
+  constructor(token: string, sandbox: string | boolean = false) {
+    const baseURL =
+      (typeof sandbox === 'string' && sandbox.toLowerCase() === "development") || sandbox === true
+        ? "https://sandbox.melhorenvio.com.br/api/v2"
+        : "https://melhorenvio.com.br/api/v2";
+
     this.axios = axios.default.create({
-      baseURL: "https://melhorenvio.com.br/api/v2",
+      baseURL,
       headers: {
         Authorization: `Bearer ${token}`,
       },
     });
   }
-
   async getShippingServices(): Promise<ShippingServiceItem[]> {
     const response = await this.axios.get("/me/shipment/calculate");
     return response.data;

--- a/src/services/melhor-envio-fulfillment.ts
+++ b/src/services/melhor-envio-fulfillment.ts
@@ -20,7 +20,7 @@ class MelhorEnvioFulfillmentService extends AbstractFulfillmentService {
     super(container);
 
     this.options = options;
-    this.client = new MelhorEnvioClient(options.apiToken);
+    this.client = new MelhorEnvioClient(options.apiToken, options.sandbox);
   }
 
   async getFulfillmentOptions(): Promise<FulfillmentItemOption[]> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 export interface Options extends Record<string, unknown> {
   apiToken: string;
   postalCode: string;
+  sandbox: string | boolean;
 }
 
 export interface CalculateRequest {


### PR DESCRIPTION
This update introduces a sandbox option to enable testing with the Melhor Envio API. The sandbox parameter has been added to the configuration and client constructor. When set to true or "development", the API will use the sandbox environment (https://sandbox.melhorenvio.com.br/api/v2) instead of the production endpoint (https://melhorenvio.com.br/api/v2). This allows for easier testing without affecting live data or production systems.