### PR TITLE
feat: :sparkles: add dynamic postal code support for shipping calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.0
 
-- Implemented dynamic postal code functionality. If the `variant` has an `originCEP` in its `metadata`, that value will be used as the origin postal code for shipping calculations. If `originCEP` is not present, the default postal code from the environment variable `MELHOR_ENVIO_POSTAL_CODE` will be used.
+- Implemented dynamic postal code functionality. If the `variant` has an `postalCodeOrigin` in its `metadata`, that value will be used as the origin postal code for shipping calculations. If `postalCodeOrigin` is not present, the default postal code from the environment variable `MELHOR_ENVIO_POSTAL_CODE` will be used.
 
 ## 1.0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## 1.1.0
+
+- Implemented dynamic postal code functionality. If the `variant` has an `originCEP` in its `metadata`, that value will be used as the origin postal code for shipping calculations. If `originCEP` is not present, the default postal code from the environment variable `MELHOR_ENVIO_POSTAL_CODE` will be used.
+
+## 1.0.3
+
+- Added support for sandbox environment.
+  - You can now test the fulfillment service in a safe environment by setting the `ENVIRONMENT` variable. If set to `"development"`, the plugin will operate in sandbox mode, allowing for testing without affecting live data.
+
 ## 1.0.0
 
-- Wellcome to first version
+- Welcome to the first version

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ Add integrated shipping calculation in your MedusaJS project with most product c
 ## Prerequisites
 
 - [Medusa backend](https://docs.medusajs.com/development/backend/install)
-- [Melhor Envio account](https://melhorenvio.com.br/)
+- [Melhor Envio account](https://melhorenvio.com.br/) or [Sandbox](https://sandbox.melhorenvio.com.br/)
 
 ## Contribute with:
 
 - ⭐ Starred this repository
 - [Follow me](https://github.com/marcosgomesneto) in github
-- Report [Inssues](https://github.com/marcosgomesneto/medusa-fulfillment-melhor-envio/issues)
+- Report [Issues](https://github.com/marcosgomesneto/medusa-fulfillment-melhor-envio/issues)
 
 ---
 
@@ -44,7 +44,7 @@ MELHOR_ENVIO_API_TOKEN=<your-token>
 MELHOR_ENVIO_POSTAL_CODE=<from-postal-code>
 ```
 
-Get your token from the Melhor Envio dashboard: https://melhorenvio.com.br.
+Get your token from the Melhor Envio dashboard: https://melhorenvio.com.br or https://sandbox.melhorenvio.com.br.
 
 Set origin zip code in the variable `MELHOR_ENVIO_POSTAL_CODE` with only numbers. This is used for shipping calculation.
 
@@ -63,6 +63,10 @@ const plugins = [
   },
 ];
 ```
+
+## New Feature: Dynamic Postal Code
+
+Starting from version `1.1.0`, you can define a custom origin postal code at the variant level. If a `variant` has the `originCEP` set in its `metadata`, this postal code will be used for shipping calculations instead of the default postal code set in `MELHOR_ENVIO_POSTAL_CODE`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ const plugins = [
 
 ## New Feature: Dynamic Postal Code
 
-Starting from version `1.1.0`, you can define a custom origin postal code at the variant level. If a `variant` has the `originCEP` set in its `metadata`, this postal code will be used for shipping calculations instead of the default postal code set in `MELHOR_ENVIO_POSTAL_CODE`.
+Starting from version `1.1.0`, you can define a custom origin postal code at the variant level. If a `variant` has the `postalCodeOrigin` set in its `metadata`, this postal code will be used for shipping calculations instead of the default postal code set in `MELHOR_ENVIO_POSTAL_CODE`.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@marcosgn/medusa-fulfillment-melhor-envio",
-    "version": "1.0.3",
+    "version": "1.1.0",
     "description": "Medusa plugin to integrate with Melhor Envio fulfillment service",
     "main": "dist/index.js",
     "repository": {

--- a/src/services/melhor-envio-fulfillment.ts
+++ b/src/services/melhor-envio-fulfillment.ts
@@ -148,7 +148,7 @@ class MelhorEnvioFulfillmentService extends AbstractFulfillmentService {
 
     let totalShippingCost = 0;
 
-    for (const originCEP in groupedProducts) {
+    for (const postalCodeOrigin in groupedProducts) {
       const products = groupedProducts[originCEP];
 
       const request: CalculateRequest = {

--- a/src/services/melhor-envio-fulfillment.ts
+++ b/src/services/melhor-envio-fulfillment.ts
@@ -118,8 +118,8 @@ class MelhorEnvioFulfillmentService extends AbstractFulfillmentService {
     );
 
     const getProductDetails = (item: LineItem) => {
-      const originCEP =
-        (item.variant.metadata?.originCEP as string) || this.options.postalCode;
+      const postalCodeOrigin =
+        (item.variant.metadata?.postalCodeOrigin as string) || this.options.postalCode;
 
       return {
         id: item.id,
@@ -128,19 +128,19 @@ class MelhorEnvioFulfillmentService extends AbstractFulfillmentService {
         length: item.variant.length || item.variant.product.length || 10,
         weight: item.variant.weight || item.variant.product.weight || 0.5,
         quantity: item.quantity,
-        originCEP,
+        postalCodeOrigin,
       };
     };
 
     const groupedProducts: Record<string, any[]> = cart.items.reduce(
       (groups, item) => {
         const productDetails = getProductDetails(item);
-        const postalCodeOrigin = productDetails.originCEP;
+        const postalCodeOrigin = productDetails.postalCodeOrigin;
 
-        if (!groups[originCEP]) {
-          groups[originCEP] = [];
+        if (!groups[postalCodeOrigin]) {
+          groups[postalCodeOrigin] = [];
         }
-        groups[originCEP].push(productDetails);
+        groups[postalCodeOrigin].push(productDetails);
         return groups;
       },
       {}
@@ -149,11 +149,11 @@ class MelhorEnvioFulfillmentService extends AbstractFulfillmentService {
     let totalShippingCost = 0;
 
     for (const postalCodeOrigin in groupedProducts) {
-      const products = groupedProducts[originCEP];
+      const products = groupedProducts[postalCodeOrigin];
 
       const request: CalculateRequest = {
         from: {
-          postal_code: originCEP,
+          postal_code: postalCodeOrigin,
         },
         to: {
           postal_code: toPostalCode,

--- a/src/services/melhor-envio-fulfillment.ts
+++ b/src/services/melhor-envio-fulfillment.ts
@@ -135,7 +135,7 @@ class MelhorEnvioFulfillmentService extends AbstractFulfillmentService {
     const groupedProducts: Record<string, any[]> = cart.items.reduce(
       (groups, item) => {
         const productDetails = getProductDetails(item);
-        const originCEP = productDetails.originCEP;
+        const postalCodeOrigin = productDetails.originCEP;
 
         if (!groups[originCEP]) {
           groups[originCEP] = [];


### PR DESCRIPTION
#### Summary

This PR introduces the **dynamic postal code** feature, which allows shipping calculations to vary based on the `originCEP` defined in each product variant's metadata. The goal of this feature is to provide more accurate and granular shipping rates by grouping items according to their origin postal codes, rather than using a single static value for all items in the cart.

#### Key Features

- **Dynamic Postal Code per Item**: Each item in the cart can now have a distinct `originCEP`, specified in the product variant's `metadata`. If the variant contains an `originCEP`, it will override the default `MELHOR_ENVIO_POSTAL_CODE` defined in the environment variables.
  
- **Fallback Mechanism**: In cases where an `originCEP` is not provided in the variant metadata, the system will continue to use the default postal code from the environment variable `MELHOR_ENVIO_POSTAL_CODE`.

- **Grouped Shipping Calculation**: Items are grouped based on their `originCEP` for shipping rate calculations, ensuring that items shipped from different locations get accurate rates for their specific shipping origins.

#### Why This Approach?

We chose to implement this feature because many stores have inventory spread across multiple locations. A static origin postal code doesn’t account for this, leading to inaccurate shipping rates or potentially higher costs for customers. By allowing items to be grouped by their postal codes, we enable a more flexible and accurate shipping experience.

#### Discussion Point: `originCEP` Placement

Currently, the `originCEP` is stored in the **variant's metadata**. This decision was made to maintain flexibility on a per-item basis and ensure backward compatibility with existing setups. However, I'm open to suggestions on whether we should store this information in a more generic location within the system or if there are other best practices for managing shipping origins across different systems. 

Do you think the `metadata` is the best place for the `originCEP`, or should we consider defining a more universal method for handling multiple shipping origins?